### PR TITLE
Partials are not imported?

### DIFF
--- a/tests/partial/_myvar.scss
+++ b/tests/partial/_myvar.scss
@@ -1,0 +1,6 @@
+@if variable-exists(import_once_value) {
+    $import_once_value: $import_once_value + 1;
+}
+@else {
+    $import_once_value: 1;
+}

--- a/tests/partial/app.scss
+++ b/tests/partial/app.scss
@@ -1,0 +1,6 @@
+@import 'myvar.scss';
+@import 'myvar.scss';
+
+#import_once {
+    contents: quote($import_once_value);
+}

--- a/tests/partial/app_wo_p.scss
+++ b/tests/partial/app_wo_p.scss
@@ -1,0 +1,6 @@
+@import 'myvarwop.scss';
+@import 'myvarwop.scss';
+
+#import_once {
+    contents: quote($import_once_value);
+}

--- a/tests/partial/expected.css
+++ b/tests/partial/expected.css
@@ -1,0 +1,2 @@
+#import_once {
+  contents: "1"; }

--- a/tests/partial/myvarwop.scss
+++ b/tests/partial/myvarwop.scss
@@ -1,0 +1,6 @@
+@if variable-exists(import_once_value) {
+    $import_once_value: $import_once_value + 1;
+}
+@else {
+    $import_once_value: 1;
+}

--- a/tests/partial/partial.js
+++ b/tests/partial/partial.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var assert = require('assert'),
+    sass = require('node-sass'),
+    path = require('path'),
+    fs = require('fs'),
+    importer = require(path.join(__dirname, '..', '..', 'index'));
+
+describe('partial', function () {
+    var mydir = path.join(__dirname);
+    it('should import files only once with partials', function (done) {
+        var file = path.join(mydir, 'app.scss');
+        var expected = fs.readFileSync(path.join(mydir, 'expected.css')).toString().trim();
+        sass.render({
+            'file': file,
+            'importer': importer
+        }, function (err, result) {
+            if (err) {
+                throw err;
+            }
+            assert.strictEqual(result.css.toString().trim(), expected);
+            done();
+        });
+    });
+
+    it('should import files only once without partials', function (done) {
+        var file = path.join(mydir, 'app_wo_p.scss');
+        var expected = fs.readFileSync(path.join(mydir, 'expected.css')).toString().trim();
+        sass.render({
+            'file': file,
+            'importer': importer
+        }, function (err, result) {
+            if (err) {
+                throw err;
+            }
+            assert.strictEqual(result.css.toString().trim(), expected);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
When you checkout this branch (and obviously after `npm install`), then if you run `./node_modules/.bin/mocha tests/partial/partial.js` you'll get a failure at `1) should import files only once with partials`.

I was thinking to fix this (so I forked it), but by reading the code, I found some comments that you're gonna do something with partials? So it's a bit premature, but I made a pull request here to ask you whether this is a bug or known issue…

Thanks.
