### PR TITLE
callback with error if a file could not be read

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,8 +300,7 @@ var importer = function importer(uri, prev, done) {
     file = path.resolve(path.dirname(prev), makeFsPath(uri));
     raf(uri, file, function (err, data) {
       if (err) {
-        console.log(err.toString());
-        done({});
+        done(err);
       }
       else {
         io(data, done);
@@ -311,8 +310,7 @@ var importer = function importer(uri, prev, done) {
   else {
     raf(uri, process.cwd(), function (err, data) {
       if (err) {
-        console.log(err.toString());
-        done({});
+        done(err);
       }
       else {
         io(data, done);


### PR DESCRIPTION
to me it makes sense to fail the build if an import path is wrong and a file could not be included.
