### PR TITLE
Fix filename resolution when importing files with extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,15 @@ var getFileNames = function getFileNames(abstractName) {
       directory,
       basename;
 
-  if (path.extname(abstractName)) {
+  if ([ '.scss', '.sass' ].indexOf(path.extname(abstractName)) !== -1) {
+    directory = path.dirname(abstractName);
+    basename = path.basename(abstractName);
+
+    [ '', '_' ].forEach(function(prefix) {
+      names.push(path.join(directory, prefix + basename));
+    });
+  }
+  else if (path.extname(abstractName)) {
     names.push(abstractName);
   }
   else {

--- a/tests/css/imported-scss.css
+++ b/tests/css/imported-scss.css
@@ -1,0 +1,2 @@
+.foo {
+  content: 'This is Foo\'s Index file'; }

--- a/tests/main.js
+++ b/tests/main.js
@@ -34,6 +34,29 @@ describe('import-once', function () {
     });
   });
 
+  it.only('should resolve import with Sass extensions', function(done) {
+    var file = filePath('import-scss.scss'),
+        expectedIncludes = [
+          file,
+          filePath('foo/_index.scss')
+        ];
+
+        sass.render({
+          'file': file,
+          'importer': importer
+        }, function (err, result) {
+          if (err) {
+            throw err;
+          }
+          should.exist(result);
+          result.stats.includedFiles.should.eql(expectedIncludes);
+          String(result.css).should.equal(
+            fs.readFileSync(path.join(__dirname, 'css/imported-scss.css'), 'utf8')
+          );
+          done();
+        });
+  })
+
   it('should import `index` files from a folder', function (done) {
     var file = filePath('import-index.scss'),
         expectedIncludes = [

--- a/tests/sass/import-scss.scss
+++ b/tests/sass/import-scss.scss
@@ -1,0 +1,1 @@
+@import 'foo/index.scss';


### PR DESCRIPTION
When Sass resolves `@import "foo/bar.scss"` it still fallsback to
`foo/_bar.scss`. Currently `getFileNames` incorrectly opts out of
the fallback behaviour for files with extensions.
