### PR TITLE
fixed error was not forwarded

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,8 +308,7 @@ var importer = function importer(uri, prev, done) {
     file = path.resolve(path.dirname(prev), makeFsPath(uri));
     raf(uri, file, function (err, data) {
       if (err) {
-        console.log(err.toString());
-        done({});
+        done(err);
       }
       else {
         io(data, done);
@@ -319,8 +318,7 @@ var importer = function importer(uri, prev, done) {
   else {
     raf(uri, process.cwd(), function (err, data) {
       if (err) {
-        console.log(err.toString());
-        done({});
+        done(err);
       }
       else {
         io(data, done);

--- a/tests/main.js
+++ b/tests/main.js
@@ -284,4 +284,16 @@ describe('import-once', function () {
       done();
     });
   });
+
+  it('should forward import errors to node-sass', function (done) {
+    var file = filePath('import-not-found.scss');
+
+    sass.render({
+      'file': file,
+      'importer': importer
+    }, function (err, result) {
+      should.exist(err);
+      done();
+    });
+  });
 });

--- a/tests/sass/import-not-found.scss
+++ b/tests/sass/import-not-found.scss
@@ -1,0 +1,1 @@
+@import 'could-not-find.scss';


### PR DESCRIPTION
fixes #35 

As described in https://github.com/sass/node-sass#importer--v200---experimental

> importers can return error and LibSass will emit that error in response. For instance:
> 
> ```js
> done(new Error('doesn\'t exist!'));
> // or return synchornously
> return new Error('nothing to do here');
> ```